### PR TITLE
[WIP] Add support for SSH access to open A8 nodes

### DIFF
--- a/iotlabwebsocket/clients/ssh_client.py
+++ b/iotlabwebsocket/clients/ssh_client.py
@@ -1,0 +1,95 @@
+"""SSH client"""
+
+import re
+import sys
+import time
+import paramiko
+
+import tornado
+from tornado import gen
+
+from ..logger import LOGGER
+
+END_STDOUT = 'End of stdout buffer. Exit'
+
+
+class SSHClient(object):
+    # pylint:disable=too-few-public-methods
+    """Class that connects to a websocket server while listening to stdin."""
+
+    def __init__(self):
+        self.host = None
+        self.username = None
+        self.on_data = None
+        self.on_close = None
+        self._ssh = None
+
+    @property
+    def ready(self):
+        return self._ssh is not None
+
+    @gen.coroutine
+    def _connect(self, host):
+        LOGGER.debug("Connect to HOST %s via SSH", host)
+        self._ssh = paramiko.SSHClient()
+        self._ssh.load_system_host_keys()
+        self._ssh.connect(hostname=host, username='root')
+        self.channel = self._ssh.get_transport().open_session()
+        self.channel.get_pty()
+        self.channel.invoke_shell()
+        self.stdin = self.channel.makefile('wb')
+        self.stdout = self.channel.makefile('r')
+        LOGGER.debug("SSH connection to '%s' opened.", host)
+
+    @gen.coroutine
+    def start(self, host, on_data, on_close):
+        """Connect and listen to a SSH server."""
+        self.host = host
+        self.on_data = on_data
+        self.on_close = on_close
+        # Connect to SSH host
+        yield self._connect(host)
+
+    @gen.coroutine
+    def send(self, command):
+        """Send data via the SSH connection."""
+        if not self.ready:
+            return
+        command = command.decode()
+        LOGGER.debug("Send command '%s' to SSH connection", command)
+        # self._listen_channel()
+        self.stdin.write(command + '\n')
+        echo_cmd = 'echo {} $?'.format(END_STDOUT)
+        self.stdin.write(echo_cmd + '\n')
+        self.stdin.flush()
+        shout = []
+        for line in self.stdout:
+            if line.startswith(command) or line.startswith(echo_cmd):
+                shout = []
+            elif line.startswith(END_STDOUT):
+                exit_status = int(line.rsplit(maxsplit=1)[1])
+                if exit_status:
+                    shout = []
+                break
+            else:
+                shout.append(re.compile(r'(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]')
+                             .sub('', line)
+                             .replace('\b', '').replace('\r', ''))
+        
+        if shout and echo_cmd in shout[-1]:
+            shout.pop()
+        # if shout and command in shout[0]:
+        #     shout.pop(0)
+
+        # LOGGER.debug(shout)
+        for line in shout:
+            # LOGGER.debug("Reply line %s", line)
+            yield self.on_data(self.host, line)
+
+    def stop(self):
+        if self.ready:
+            LOGGER.debug("Stopping SSH connection")
+            self._ssh.close()
+            self._ssh = None
+        elif self.host is not None:
+            self.on_close(self.host)

--- a/iotlabwebsocket/clients/ssh_client.py
+++ b/iotlabwebsocket/clients/ssh_client.py
@@ -30,7 +30,7 @@ class SSHClient(object):
         LOGGER.debug("Connect to host %s via SSH", self.host)
         self._ssh = paramiko.SSHClient()
         try:
-            self._ssh.load_system_host_keys()
+            self._ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             host = self.host
             if host.startswith('a8'):
                 host = 'node-a8-{}'.format(host.split('-')[-1])

--- a/iotlabwebsocket/clients/ssh_client.py
+++ b/iotlabwebsocket/clients/ssh_client.py
@@ -31,7 +31,10 @@ class SSHClient(object):
         self._ssh = paramiko.SSHClient()
         try:
             self._ssh.load_system_host_keys()
-            self._ssh.connect(hostname=self.host, username=self.username)
+            host = self.host
+            if host.startswith('a8'):
+                host = 'node-a8-{}'.format(host.split('-')[-1])
+            self._ssh.connect(hostname=host, username=self.username)
             self._channel = self._ssh.get_transport().open_session()
             self._channel.get_pty()
             self._channel.invoke_shell()

--- a/iotlabwebsocket/handlers/websocket_handler.py
+++ b/iotlabwebsocket/handlers/websocket_handler.py
@@ -16,7 +16,7 @@ class WebsocketClientHandler(websocket.WebSocketHandler):
         self.site, self.experiment_id, self.node, self.type = \
             path.split('/')[-4:]
         msg = None
-	if self.type == 'ssh' and not self.node.startswith('node-'):
+        if self.type == 'ssh' and not self.node.startswith('a8-'):
             msg = "ssh not allowed on node '{}'".format(self.node)
 
         if msg is not None:
@@ -94,8 +94,9 @@ class WebsocketClientHandler(websocket.WebSocketHandler):
 
         LOGGER.info("Websocket connection request")
 
-        # Check path is always True
-        self._check_path()
+        # Check path is correct
+        if not self._check_path():
+            return
 
         # Verify token provided in subprotocols, since there's an asynchronous
         # call to the API, we wait for it to complete.

--- a/iotlabwebsocket/tests/test_web_application.py
+++ b/iotlabwebsocket/tests/test_web_application.py
@@ -59,7 +59,7 @@ class TestWebApplication(AsyncHTTPTestCase):
         nodes.return_value = json.dumps({'nodes': ['node-1.local']})
 
         websocket = yield tornado.websocket.websocket_connect(
-            url, subprotocols=['token', 'token'])
+            url, subprotocols=['user', 'token', 'token'])
 
         assert len(self.application.serial_websockets['node-1']) == 1
         assert self.application.serial_websockets['node-1'][0].user == 'user'
@@ -80,7 +80,7 @@ class TestWebApplication(AsyncHTTPTestCase):
         # TCP connection
         start.call_count = 0
         websocket2 = yield tornado.websocket.websocket_connect(
-            url, subprotocols=['token', 'token'])
+            url, subprotocols=['user', 'token', 'token'])
 
         assert start.call_count == 0
         assert len(self.application.serial_websockets['node-1']) == 2

--- a/iotlabwebsocket/tests/test_websocket_handler.py
+++ b/iotlabwebsocket/tests/test_websocket_handler.py
@@ -28,7 +28,7 @@ class TestWebsocketHandler(AsyncHTTPTestCase):
 
     @patch('iotlabwebsocket.handlers.http_handler._nodes')
     @gen_test
-    def test_websocket_connection(self, nodes, ws_open):
+    def test_websocket_serial_connection(self, nodes, ws_open):
         url = ('ws://localhost:{}/ws/local/123/node-1/serial'
                .format(self.api.port))
         nodes.return_value = json.dumps({'nodes': ['node-1.local']})
@@ -40,6 +40,10 @@ class TestWebsocketHandler(AsyncHTTPTestCase):
         # if handle_websocket_open is called, the connection have passed all
         # checks with success
         ws_open.assert_called_once()
+        args, _ = ws_open.call_args
+        assert len(args) == 2
+        assert isinstance(args[0], WebsocketClientHandler)
+        assert args[1] == 'serial'
 
         with patch('iotlabwebsocket.web_application'
                    '.WebApplication.handle_websocket_data') as ws_data:
@@ -48,9 +52,52 @@ class TestWebsocketHandler(AsyncHTTPTestCase):
             yield gen.sleep(0.1)
             ws_data.assert_called_once()
             args, _ = ws_data.call_args
-            assert len(args) == 2
+            assert len(args) == 3
             assert isinstance(args[0], WebsocketClientHandler)
             assert args[1] == data
+            assert args[2] == 'serial'
+            ws_handler = args[0]
+
+        with patch('iotlabwebsocket.web_application'
+                   '.WebApplication.handle_websocket_close') as ws_close:
+            connection.close()
+            yield gen.sleep(0.1)
+            ws_close.assert_called_once()
+            args, _ = ws_close.call_args
+            assert len(args) == 2
+            assert args[0] == ws_handler
+            assert args[1] == 'serial'
+
+    @patch('iotlabwebsocket.handlers.http_handler._nodes')
+    @gen_test
+    def test_websocket_ssh_connection(self, nodes, ws_open):
+        url = ('ws://localhost:{}/ws/local/123/a8-1/ssh'
+               .format(self.api.port))
+        nodes.return_value = json.dumps({'nodes': ['a8-1.local']})
+
+        connection = yield tornado.websocket.websocket_connect(
+            url, subprotocols=['token', 'token'])
+        assert connection.selected_subprotocol == 'token'
+
+        # if handle_websocket_open is called, the connection have passed all
+        # checks with success
+        ws_open.assert_called_once()
+        args, _ = ws_open.call_args
+        assert len(args) == 2
+        assert isinstance(args[0], WebsocketClientHandler)
+        assert args[1] == 'ssh'
+
+        with patch('iotlabwebsocket.web_application'
+                   '.WebApplication.handle_websocket_data') as ws_data:
+            data = "test"
+            yield connection.write_message(data)
+            yield gen.sleep(0.1)
+            ws_data.assert_called_once()
+            args, _ = ws_data.call_args
+            assert len(args) == 3
+            assert isinstance(args[0], WebsocketClientHandler)
+            assert args[1] == data
+            assert args[2] == 'ssh'
             ws_handler = args[0]
 
             # Check some websocket handler internal methods (just for coverage)
@@ -67,7 +114,10 @@ class TestWebsocketHandler(AsyncHTTPTestCase):
             connection.close(code=1000, reason="client exit")
             yield gen.sleep(0.1)
             ws_close.assert_called_once()
-            ws_close.assert_called_with(ws_handler)
+            args, _ = ws_close.call_args
+            assert len(args) == 2
+            assert args[0] == ws_handler
+            assert args[1] == 'ssh'
 
     @gen_test
     def test_websocket_connection_invalid_url(self, ws_open):
@@ -114,4 +164,13 @@ class TestWebsocketHandler(AsyncHTTPTestCase):
             _ = yield tornado.websocket.websocket_connect(
                 url, subprotocols=['user', 'token', 'token'])
         assert "HTTP 401: Unauthorized" in str(exc_info)
+        assert ws_open.call_count == 0
+
+        url = ('ws://localhost:{}/ws/local/123/node-1/ssh'  # only a8 allowed
+               .format(self.api.port))
+
+        with pytest.raises(tornado.httpclient.HTTPClientError) as exc_info:
+            _ = yield tornado.websocket.websocket_connect(
+                url, subprotocols=['token', 'token'])
+        assert "HTTP 404: Not Found" in str(exc_info)
         assert ws_open.call_count == 0

--- a/iotlabwebsocket/tests/test_websocket_handler.py
+++ b/iotlabwebsocket/tests/test_websocket_handler.py
@@ -60,7 +60,7 @@ class TestWebsocketHandler(AsyncHTTPTestCase):
 
         with patch('iotlabwebsocket.web_application'
                    '.WebApplication.handle_websocket_close') as ws_close:
-            connection.close()
+            connection.close(code=1234, reason='test')
             yield gen.sleep(0.1)
             ws_close.assert_called_once()
             args, _ = ws_close.call_args
@@ -76,7 +76,7 @@ class TestWebsocketHandler(AsyncHTTPTestCase):
         nodes.return_value = json.dumps({'nodes': ['a8-1.local']})
 
         connection = yield tornado.websocket.websocket_connect(
-            url, subprotocols=['token', 'token'])
+            url, subprotocols=['user', 'token', 'token'])
         assert connection.selected_subprotocol == 'token'
 
         # if handle_websocket_open is called, the connection have passed all

--- a/iotlabwebsocket/web_application.py
+++ b/iotlabwebsocket/web_application.py
@@ -4,8 +4,11 @@ from collections import defaultdict
 
 import tornado
 
+from tornado import gen
+
 from . import DEFAULT_API_HOST
 from .logger import LOGGER
+from .clients.ssh_client import SSHClient
 from .clients.tcp_client import TCPClient
 from .handlers.http_handler import HttpApiRequestHandler
 from .handlers.websocket_handler import WebsocketClientHandler
@@ -21,6 +24,8 @@ class WebApplication(tornado.web.Application):
         settings = {'debug': True}
         handlers = [
             (r"/ws/[a-z]+/[0-9]+/[a-z0-9]+-?[a-z0-9]*-?[0-9]*/serial",
+             WebsocketClientHandler, dict(api=api)),
+            (r"/ws/[a-z]+/[0-9]+/[a-z0-9]+-?[a-z0-9]*-?[0-9]*/ssh",
              WebsocketClientHandler, dict(api=api))
         ]
 
@@ -31,22 +36,21 @@ class WebApplication(tornado.web.Application):
                              HttpApiRequestHandler, dict(token=token)))
 
         self.tcp_clients = defaultdict(TCPClient)
-        self.websockets = defaultdict(list)
+        self.serial_websockets = defaultdict(list)
         self.user_connections = defaultdict(int)
+
+        self.ssh_clients = defaultdict(SSHClient)
+        self.ssh_websockets = defaultdict(list)
 
         super(WebApplication, self).__init__(handlers, **settings)
 
-    def handle_websocket_open(self, websocket):
-        """Handle the websocket connection once authentified."""
-        node = websocket.node
-        user = websocket.user
-        site = websocket.site
+    def _websocket_serial_open(self, websocket, user, site, node):
         tcp_client = self.tcp_clients[node]
-        if not self.websockets[node]:
+        if not self.serial_websockets[node]:
             # Open the tcp connection on first websocket connection.
             tcp_client.start(node, on_data=self.handle_tcp_data,
                              on_close=self.handle_tcp_close)
-        if len(self.websockets[node]) == MAX_WEBSOCKETS_PER_NODE:
+        if len(self.serial_websockets[node]) == MAX_WEBSOCKETS_PER_NODE:
             websocket.close(
                 code=1000,
                 reason=("Cannot open more than {} connections to node {}."
@@ -59,10 +63,37 @@ class WebApplication(tornado.web.Application):
                         .format(MAX_WEBSOCKETS_PER_USER, user, site)))
         else:
             self.user_connections[user] += 1
-            self.websockets[node].append(websocket)
+            self.serial_websockets[node].append(websocket)
 
-    def handle_websocket_data(self, websocket, data):
-        """Handle a message coming from a websocket."""
+    def _websocket_ssh_open(self, websocket, user, site, node):
+        ssh_client = self.ssh_clients[node]
+        if not self.ssh_websockets[node]:
+            # Open the tcp connection on first websocket connection.
+            ssh_client.start(node, on_data=self.handle_ssh_data,
+                             on_close=self.handle_ssh_close)
+        if self.user_connections[user] == MAX_WEBSOCKETS_PER_USER:
+            websocket.close(
+                code=1000,
+                reason=("Max number of connections ({}) reached for user {} "
+                        "on site {}."
+                        .format(MAX_WEBSOCKETS_PER_USER, user, site)))
+        else:
+            self.user_connections[user] += 1
+            self.ssh_websockets[node].append(websocket)
+
+    def handle_websocket_open(self, websocket, client_type):
+        """Handle the websocket connection once authentified."""
+        node = websocket.node
+        user = websocket.user
+        site = websocket.site
+        if client_type == "serial":
+            self._websocket_serial_open(websocket, user, site, node)
+        elif client_type == "ssh":
+            self._websocket_ssh_open(websocket, user, site, node)
+        else:
+            LOGGER.debug("Invalid client type '%s'", client_type)
+
+    def _websocket_serial_data(self, websocket, data):
         tcp_client = self.tcp_clients[websocket.node]
         if tcp_client.ready:
             tcp_client.send(data.encode())
@@ -71,35 +102,88 @@ class WebApplication(tornado.web.Application):
             websocket.write_message("No TCP connection opened, cannot send "
                                     "message '{}'.\n".format(data))
 
-    def handle_websocket_close(self, websocket):
-        """Handle the disconnection of a websocket."""
-        node = websocket.node
-        user = websocket.user
+    def _websocket_ssh_data(self, websocket, data):
+        ssh_client = self.ssh_clients[websocket.node]
+        if ssh_client.ready:
+            ssh_client.send(data.encode())
+        else:
+            LOGGER.debug("No SSH connection opened, skipping message")
+            websocket.write_message("No SSH connection opened, cannot send "
+                                    "message '{}'.\n".format(data))
+
+    def handle_websocket_data(self, websocket, data, client_type='serial'):
+        """Handle a message coming from a websocket."""
+        if client_type == "serial":
+            self._websocket_serial_data(websocket, data)
+        elif client_type == "ssh":
+            self._websocket_ssh_data(websocket, data)
+        else:
+            LOGGER.debug("Invalid client type '%s'", client_type)
+
+    def _websocket_serial_close(self, websocket, node):
         tcp_client = self.tcp_clients[node]
-        if websocket in self.websockets[node]:
-            self.websockets[node].remove(websocket)
-        if self.user_connections[user] > 0:
-            self.user_connections[user] -= 1
+        self.serial_websockets[node].remove(websocket)
 
         # websockets list is now empty for given node, closing tcp connection.
-        if tcp_client.ready and not self.websockets[node]:
+        if tcp_client.ready and not self.serial_websockets[node]:
             LOGGER.debug("Closing TCP connection to node '%s'", node)
             tcp_client.stop()
             self.tcp_clients.pop(node)
             del tcp_client
 
+    def _websocket_ssh_close(self, websocket, node):
+        ssh_client = self.ssh_clients[websocket.node]
+        self.ssh_websockets[node].remove(websocket)
+
+        # websockets list is now empty for given node, closing tcp connection.
+        if ssh_client.ready and not self.ssh_websockets[node]:
+            LOGGER.debug("Closing SSH connection to node '%s'", node)
+            ssh_client.stop()
+            del ssh_client
+
+    def handle_websocket_close(self, websocket, client_type):
+        """Handle the disconnection of a websocket."""
+        node = websocket.node
+        user = websocket.user
+        tcp_client = self.tcp_clients[node]
+        if client_type == "serial":
+            self._websocket_serial_close(websocket, node)
+        elif client_type == "ssh":
+            self._websocket_ssh_close(websocket, node)
+        else:
+            LOGGER.debug("Invalid client type '%s'", client_type)
+
+        if self.user_connections[user] > 0:
+            self.user_connections[user] -= 1
+
     def handle_tcp_data(self, node, data):
         """Forwards data from TCP connection to all websocket clients."""
-        for websocket in self.websockets[node]:
+        for websocket in self.serial_websockets[node]:
             websocket.write_message(data)
 
     def handle_tcp_close(self, node, reason="Cannot connect"):
         """Close all websockets connected to a node when TCP is closed."""
-        for websocket in self.websockets[node]:
+        for websocket in self.serial_websockets[node]:
             websocket.close(code=1000, reason=reason)
+
+    @gen.coroutine
+    def handle_ssh_data(self, node, data):
+        """Forwards data from SSH connection to all websocket clients."""
+        for websocket in self.ssh_websockets[node]:
+            websocket.write_message(data)
+
+    def handle_ssh_close(self, node):
+        """Close all websockets connected to a node when SSH is closed."""
+        for websocket in self.ssh_websockets[node]:
+            websocket.close(code=1000,
+                            reason="Connection to {} is closed".format(node))
 
     def stop(self):
         """Stop any pending websocket connection."""
-        for websockets in self.websockets.values():
+        for websockets in self.serial_websockets.values():
+            for websocket in websockets:
+                websocket.close(code=1001, reason="server is restarting")
+
+        for websockets in self.ssh_websockets.values():
             for websocket in websockets:
                 websocket.close(code=1001, reason="server is restarting")

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,9 @@ if __name__ == '__main__':
               ],
           },
           install_requires=[
-            'tornado>=5.1',
+            'tornado>=5.1', 'paramiko==2.1.4',
+            'cffi', 'setuptools', 'bcrypt', 'pynacl', 'cryptography',
+            'ipaddress', 'enum34'
           ],
           classifiers=[
             'Development Status :: 4 - Beta',


### PR DESCRIPTION
This PR adds support for accessing by SSH an open-a8 node via websockets.

In the current design, each websocket connection opens a new SSH connection (different from TCP where all websocket connection access the TCP connection to a node).

This PR is marked because the new SSHClient class is not tested (yet). Performance has not been tested.
Functionally, it works and was already tested on devsaclay site.