### PR TITLE
tcp_client: enable support for unicode characters

### DIFF
--- a/iotlabwebsocket/clients/tcp_client.py
+++ b/iotlabwebsocket/clients/tcp_client.py
@@ -70,7 +70,7 @@ class TCPClient(object):
             while True:
                 data = yield self._tcp.read_bytes(CHUNK_SIZE, partial=True)
                 try:
-                    data_decoded = data.decode()
+                    data_decoded = data.decode('utf-8')
                 except UnicodeDecodeError:
                     LOGGER.warning("Cannot decode data received via TCP.")
                     continue

--- a/iotlabwebsocket/tests/test_tcp_client.py
+++ b/iotlabwebsocket/tests/test_tcp_client.py
@@ -1,4 +1,5 @@
 """iotlabwebsocket tcp client tests."""
+# -*- coding: utf-8 -*-
 
 import sys
 import unittest
@@ -78,11 +79,20 @@ class NodeHandlerTest(AsyncTestCase):
         server.stream.write(message)
         yield gen.sleep(0.01)
         assert on_data.call_count == 0
+        assert not server.received
 
         # Data sent by the node_handler should be received by the TCPServer:
-        assert not server.received
         client.send(b'test')
         yield gen.sleep(0.01)
+        on_data.call_count == 1
+        assert server.received
+
+        # Sending unicode character works
+        on_data.call_count = 0
+        server.received = False
+        client.send(b'éééààà°°°°')
+        yield gen.sleep(0.01)
+        on_data.call_count == 1
         assert server.received
 
         # Sending from the node handler without an opened connection has

--- a/iotlabwebsocket/tests/test_web_application.py
+++ b/iotlabwebsocket/tests/test_web_application.py
@@ -1,4 +1,5 @@
 """iotlabwebsocket web application tests."""
+# -*- coding: utf-8 -*-
 
 import json
 
@@ -135,7 +136,7 @@ class TestWebApplication(AsyncHTTPTestCase):
         # Send some data
         websocket_srv = self.application.websockets['localhost'][0]
         websocket_srv.write_message = mock.Mock()
-        yield server.stream.write(b"test")
+        yield server.stream.write(b"test°°°ééààà")
 
         yield gen.sleep(0.1)
         assert websocket_srv.write_message.call_count == 1

--- a/iotlabwebsocket/web_application.py
+++ b/iotlabwebsocket/web_application.py
@@ -65,7 +65,7 @@ class WebApplication(tornado.web.Application):
         """Handle a message coming from a websocket."""
         tcp_client = self.tcp_clients[websocket.node]
         if tcp_client.ready:
-            tcp_client.send(data.encode())
+            tcp_client.send(data.encode('utf-8'))
         else:
             LOGGER.debug("No TCP connection opened, skipping message")
             websocket.write_message("No TCP connection opened, cannot send "


### PR DESCRIPTION
Allow any unicode to be transferred between the TCP connection and the websocket. I was stupid to not do it this way initially: it's not possible to send character such as `°` and some RIOT examples are broken via the web terminal because of this.

Some adaption is also required on the webportal.